### PR TITLE
Fix bug with options that are an array

### DIFF
--- a/ClosureCompiler.js
+++ b/ClosureCompiler.js
@@ -221,10 +221,10 @@
                     value = [value];
                 }
                 for (j=0; j<value.length; j++) {
-                    if (!/[^\s]*/.test(value)) {
-                        throw(new Error("Illegal value for option "+key+": "+value));
+                    if (!/[^\s]*/.test(value[j])) {
+                        throw(new Error("Illegal value for option "+key+": "+value[j]));
                     }
-                    args += ' --'+key+' '+value;
+                    args += ' --'+key+' '+value[j];
                 }
             }
         }


### PR DESCRIPTION
For example:
`options.define = ['VARIABLE=false', 'ANOTHER_VARIABLE=true']`

currently translates into `--define VARIABLE=false,ANOTHER_VARIABLE=true --define VARIABLE=false,ANOTHER_VARIABLE=true`

when the correct result is  `--define VARIABLE=false --define ANOTHER_VARIABLE=true`
