### PR TITLE
Increase compilation speed by 2x

### DIFF
--- a/ClosureCompiler.js
+++ b/ClosureCompiler.js
@@ -151,7 +151,7 @@
         delete options["js"];
         delete options["js_output_file"];
         
-        var args = '-jar "'+__dirname+'/compiler/compiler.jar"';
+        var args = '-client -d32 -jar "'+__dirname+'/compiler/compiler.jar"';
         
         // Source files
         if (!(files instanceof Array)) {


### PR DESCRIPTION
One simple command line option change for much better compile speed. See [this Closure FAQ entry](https://code.google.com/p/closure-compiler/wiki/FAQ#What_are_the_recommended_Java_VM_command-line_options?).
