### PR TITLE
Added missing closing square bracket to the API example within the READM...

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The API is quite simple and fully explained in a few lines of code:
 var ClosureCompiler = require("closurecompiler");
 
 ClosureCompiler.compile(
-    ['file1.js', 'file2.js',
+    ['file1.js', 'file2.js'],
     {
         // Options in the API exclude the "--" prefix
         compilation_level: "ADVANCED_OPTIMIZATIONS",


### PR DESCRIPTION
Added missing closing square bracket to the API example within the README. I did that because the example actually fooled me into thinking that the options object has to be passed in as the last argument of the array, which is clearly wrong. Hopefully with this change no one will make this mistake again.
