### PR TITLE
Proper escaping of command line args + forward stdin

### DIFF
--- a/bin/ccjs
+++ b/bin/ccjs
@@ -77,7 +77,7 @@ for (var i=2; i<process.argv.length; i++) {
 }
 
 // Run it
-ClosureCompiler.compile(files, options, function(error, result) {
+ClosureCompiler.compile(files, options, process.stdin, function(error, result) {
     if (help && typeof error == 'string') {
         error = error.replace(/(\-\-[a-zA-Z0-9_]+) ([^ ])/g, function($, $1, $2) {
             return $1+"="+$2;

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "dependencies": {
         "tar": "0.1.20",
         "closurecompiler-externs": "*",
+        "concat-stream": "~1.4.6",
         "jsdoc": "~3.3.0-alpha10"
     },
     "license": "Apache License, Version 2.0",


### PR DESCRIPTION
This pull request
- allows `ccjs` to read from stdin
- uses `child_process.spawn`, which allows for proper escaping of shell arguments. E.g.: `--output_wrapper="(function(){%output%}());"` works now.
