### PR TITLE
Also listen for the "error" event

### DIFF
--- a/ClosureCompiler.js
+++ b/ClosureCompiler.js
@@ -29,6 +29,7 @@
     var path = require("path"),
         fs = require("fs"),
         child_process = require("child_process"),
+        once = require('one-time'),
         concat = require('bl');
 
     if (!fs.existsSync) fs.existsSync = path.existsSync; // node < 0.8
@@ -255,6 +256,7 @@
         
         // Executes a command
         function exec(cmd, args, stdin, callback) {
+            var cb = once(callback);
             var stdout = concat();
             var stderr = concat();
 
@@ -263,14 +265,15 @@
             });
             process.stdout.pipe(stdout);
             process.stderr.pipe(stderr);
+            process.on('error', cb);
             process.on('exit', function(code, signal) {
               var err;
-              if (code) {
+              if (code !== 0) {
                 err = new Error(code);
                 err.code = code;
                 err.signal = signal;
               }
-              callback(err, stdout, stderr);
+              cb(err, stdout, stderr);
             });
         }
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
         "tar": "0.1.20",
         "closurecompiler-externs": "*",
         "bl": "~0.9.3",
+        "one-time": "0.0.2",
         "jsdoc": "~3.3.0-alpha10"
     },
     "license": "Apache License, Version 2.0",


### PR DESCRIPTION
Ensure the callback to "exec" is called only once, as "exit" might still
be called, even after the "error" event.