### PR TITLE
Allow quoted js source references to support minimatch globs

### DIFF
--- a/ClosureCompiler.js
+++ b/ClosureCompiler.js
@@ -276,6 +276,9 @@
               }
               callback(err, stdout, stderr);
             });
+            process.on('error', function (err) {
+              callback(err, stdout, stderr);
+            });
         }
 
         // Run it

--- a/ClosureCompiler.js
+++ b/ClosureCompiler.js
@@ -182,14 +182,18 @@
             files = [files];
         }
         for (i=0; i<files.length; i++) {
-            if (typeof files[i] != 'string' || files[i].indexOf('"') >= 0) {
+            if (typeof files[i] != 'string') {
                 throw(new Error("Illegal source file: "+files[i]));
             }
-            stat = fs.statSync(files[i]);
-            if (!stat.isFile()) {
-                throw(new Error("Source file not found: "+files[i]));
+            if (files[i].indexOf('"') >= 0) {
+                args.push('--js=' + files[i]);
+            } else {
+                stat = fs.statSync(files[i]);
+                if (!stat.isFile()) {
+                    throw (new Error("Source file not found: " + files[i]));
+                }
+                args.push('--js', files[i]);
             }
-            args.push('--js', files[i]);
         }
         
         // Externs files


### PR DESCRIPTION
Closure-compiler now supports [minimatch-style glob inputs](https://github.com/google/closure-compiler#compiling-multiple-scripts). This allows for very large number of files to be passed to the compiler. On windows, command length arguments prohibit passing large source repositories (like all of closure-library) to the compiler directly.

```
java -jar compiler.jar --js="mylibrary/**.js" --js mysource.js
```

To support this functionality, I allowed input sources to be quoted, and if so did not verify that they match an existing file.

I also added an error event so that invalid compiler option error messages would be correctly reported.