### PR TITLE
Better check for node.js context

### DIFF
--- a/ClosureCompiler.js
+++ b/ClosureCompiler.js
@@ -21,7 +21,7 @@
  */
 (function(global) {
     
-    if ((typeof window != 'undefined' && !!window.window) || typeof require != 'function') {
+    if (typeof require != 'function' || !module || !module.exports || !process) {
         throw(new Error("ClosureCompiler.js can only be used within node.js"));
     }
 


### PR DESCRIPTION
Checking for `window` will produce a false negative in some contexts, such as [iron-node](https://github.com/s-a/iron-node) (I tested this, it fails) and possibly [NW.js](https://github.com/nwjs/nw.js) (untested, but I suspect it might also fail) which provide both node features like `require`, `module`, and `process`, as well as `window`.

This tweak checks more explicitly for things that are exclusive to node and should not produce a false negative if node features and `window` are both present.